### PR TITLE
Update Overwatch 2 Presences: Grouping and Stadium

### DIFF
--- a/presences/O/Overwatch 2/index.ts
+++ b/presences/O/Overwatch 2/index.ts
@@ -68,6 +68,18 @@ presence.on('richPresenceUpdate', async steamPresence => {
     presenceData.largeImageText = details;
     presenceData.details = details;
   }
+  const groupSize = Number(steamPresence?.presence?.steam_player_group_size || 1);
+  const groupId = steamPresence?.presence?.steam_player_group;
+  const defaultGroupMax = 5;
+  if (groupId) {
+    presenceData.partyId = groupId;
+    presenceData.partySize = groupSize;
+    presenceData.partyMax = groupSize > defaultGroupMax ? groupSize : 5;
+    if (!details) {
+      presenceData.state = 'In Group';
+      presenceData.details = state;
+    }
+  }
   if (!['In Menu', 'Match Ending'].includes(state)) {
     presenceData.startTimestamp = Date.now();
   }

--- a/presences/O/Overwatch 2/index.ts
+++ b/presences/O/Overwatch 2/index.ts
@@ -13,7 +13,9 @@ const GameModeIcons: { [key: string]: string } = {
   'Deathmatch': 'quick_play',
   'Hero Mastery': 'hero_mastery',
   'Story Mission': 'story_mission',
-  'Stadium': 'stadium'
+  'Stadium': 'stadium',
+  'Stadium Quick Play': 'stadium',
+  'Stadium Competitive': 'stadium_competitive'
 };
 
 presence.on('richPresenceUpdate', async steamPresence => {

--- a/presences/O/Overwatch 2/metadata.json
+++ b/presences/O/Overwatch 2/metadata.json
@@ -3,7 +3,7 @@
 	"app_id": 2357570,
 	"name": "Overwatch 2",
 	"description": "Overwatch 2 is a critically acclaimed, team-based shooter game set in an optimistic future with an evolving roster of heroes.",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"author": {
 		"name": "WizardCM",
 		"github": "WizardCM"


### PR DESCRIPTION
### Stadium

* Game mode was split into Quick Play and Competitive
* Stadium Competitive has a new icon

<img width="363" height="160" alt="2026-02-01_16-50-04" src="https://github.com/user-attachments/assets/fcc5f9df-b5a8-43f8-ba55-1b39051acc19" />

### Grouping

* Added grouping detection
* Defaults to max of 5 (standard size)
* Adjusts max automatically if group is larger (eg. playing 6v6 Open Queue or Custom Game)
* Swaps In Menu & In Group text compared to other modes

<img width="366" height="157" alt="2026-02-01_16-49-50" src="https://github.com/user-attachments/assets/967cfc5c-3ae5-4b55-bf5f-80cc0b999f5f" />

<img width="367" height="157" alt="2026-02-01_16-47-20" src="https://github.com/user-attachments/assets/63fc8e5c-2456-4bc9-8c49-a61241a852e5" />

<img width="235" height="111" alt="2026-02-01_16-46-17" src="https://github.com/user-attachments/assets/2c55a7ef-d16d-47cd-b87f-1688aa28c92d" />

